### PR TITLE
修复`create`一个不存在的目录时报错问题

### DIFF
--- a/chunyun/create_command.py
+++ b/chunyun/create_command.py
@@ -22,18 +22,19 @@ password =
 class CreateCommand(Command):
 
     def run(self):
+
         # 初始化config.ini文件
         config_path = os.path.join(self.args.dirname, 'config.ini')
-        print("Creating config file {}".format(config_path))
         if os.path.exists(config_path):
             raise Exception("已经在目录下初始化过！")
-
-        with open(config_path, "w") as handle:
-            handle.write(CONFIG_TPL)
 
         # 创建migrations目录
         migrations_path = os.path.join(self.args.dirname, "migrations")
         print("Creating directory {}".format(migrations_path))
         os.makedirs(migrations_path)
+
+        print("Creating config file {}".format(config_path))
+        with open(config_path, "w") as handle:
+            handle.write(CONFIG_TPL)
 
         print("成功创建项目，请配置config.ini文件")

--- a/chunyun/make_command.py
+++ b/chunyun/make_command.py
@@ -1,7 +1,6 @@
 import os
-
-from .command import Command
 import random
+from .command import Command
 
 
 SQL_TPL = """


### PR DESCRIPTION
例如（如果test目录不存在）：
`chunyun create test`

会报如下错误：
`
Creating config file test/config.ini 
Error:  [Errno 2] No such file or directory: 'test/config.ini'
`

因此更改了创建目录文件的逻辑来修复此问题
